### PR TITLE
refactor: переделал логику пагинации

### DIFF
--- a/src/hooks/use-paging-observer.jsx
+++ b/src/hooks/use-paging-observer.jsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from 'react';
 
-function usePagingObserver(ref, loading, page, totalPages, setPage) {
+function usePagingObserver(ref, loading, setPage, isNextPage) {
   const observer = useRef();
 
   useEffect(() => {
@@ -8,8 +8,8 @@ function usePagingObserver(ref, loading, page, totalPages, setPage) {
     if (!ref.current) return;
 
     const callbackObserver = (entries) => {
-      if (entries[0].isIntersecting && page < totalPages) {
-        setPage(page + 1);
+      if (entries[0].isIntersecting && isNextPage) {
+        setPage();
       }
     };
 

--- a/src/pages/contacts-page/contacts-page.jsx
+++ b/src/pages/contacts-page/contacts-page.jsx
@@ -9,35 +9,30 @@ import usePagingObserver from '../../hooks/use-paging-observer';
 const ContactsPage = observer(() => {
   const { contactsStore, userStore } = useStore();
   const {
-    contacts,
-    count,
+    offset,
+    isNextPage,
     search,
-    page,
-    totalPages,
+    contacts,
     loading,
     error,
-    resetContacts,
     setPage,
     setSearch,
     getContacts,
-    getNextPage,
   } = contactsStore;
   const {
     user: { id },
   } = userStore;
   const ref = useRef();
 
-  usePagingObserver(ref, loading, page, totalPages, setPage);
-
-  useEffect(() => () => resetContacts(), [resetContacts]);
+  usePagingObserver(ref, loading, setPage, isNextPage);
 
   useEffect(() => {
     getContacts();
   }, [getContacts, search]);
 
   useEffect(() => {
-    getNextPage();
-  }, [getNextPage, page]);
+    getContacts(true);
+  }, [getContacts, offset]);
 
   return (
     <article>
@@ -54,7 +49,7 @@ const ContactsPage = observer(() => {
           <div ref={ref} />
         </>
       )}
-      {search && !count && !error && (
+      {search && !contacts.length && !error && !loading && (
         <p>К сожалению, поиск не дал результатов</p>
       )}
     </article>


### PR DESCRIPTION
- Переделал пагинацию для новых параметров запроса (limit и offset вместо page);
- Убрал очистку списка контактов при уходе со страницы. Теперь, если перейти на страницу контакта, нажав на карточку юзера, а потом вернуться обратно по кнопке "назад" браузера, скролл возвращается к этой карточке. Посмотрите, не знаю, насколько это удобно, можно вернуть прошлый вариант (очистку списка, тогда скролл всегда наверху и при входе на страницу по ссылке и при нажатии "назад" со страницы контакта).  